### PR TITLE
Allow time and frame number in `-b` `-e`, `-dt`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+*.so
+/*.egg-info
+*.pyc
+__pycache__
+/build
+/dist
+*.DS_store
+*.npz
+*.dat
+*.npy
+*.txt
+*.xvg
+.duecredit.p

--- a/cli_main.py
+++ b/cli_main.py
@@ -93,18 +93,19 @@ def convert_str_time(x, dt):
     """
 
     # regex to split value and units while handling scientific input
-    type_regex = re.compile(r"(?!e)\d+|\D+")
-    res = type_regex.findall(x)
+    type_regex = re.compile(r'((-?\d{1,}e?E?-?\d*)|[a-z]*$)')
+    val_, unit_, *_ = type_regex.findall(x)
 
     try:
-        if len(res) == 2:
-            val, unit = res
-            val = mda.units.convert(float(val), unit, "ps")
+        val, unit = float(val_[0]), unit_[0]
+        if unit != "":
+            val = mda.units.convert(val, unit, "ps")
             frame = int(val // dt)
         else:
-            frame = int(x)
+            frame = int(val)
     except (TypeError, ValueError):
-        raise ValueError("Only integers or time step combinations (´12ps´) are valid for frame selection")
+        raise ValueError("Only integers or time step combinations (´12ps´) "
+                         "are valid for frame selection")
 
     return frame
 

--- a/cli_main.py
+++ b/cli_main.py
@@ -69,6 +69,47 @@ def _warning(message,
 warnings.showwarning = _warning
 
 
+def convert_str_time(x, dt):
+    """
+    Converts a string x into a frame number based on given `dt`.
+    If `x` does not contain any units its assumed to be a frame number already.
+
+    Parameters
+    ----------
+    x : str
+        the input string
+    dt : float
+        the time step in ps
+
+    Returns
+    -------
+    int
+        frame number
+
+    Raises
+    ------
+    ValueError
+        The input does not contain any units but is not an integer.
+    """
+
+    # regex to split value and units while handling scientific input
+    type_regex = re.compile(r"(?!e)[a-z]")
+    res = type_regex.findall(x)
+
+    if len(res) > 0:  # input has units
+        val, unit = x.split(res[0])
+        unit = res[0] + unit
+        val = mda.units.convert(float(val), unit, "ps")
+        frame = int(val//dt)
+    else:
+        try:
+            frame = int(x)
+        except ValueError:
+            raise ValueError("Only integers are valid for frame selection")
+
+    return frame
+
+
 def parse_callable_signature(callable_obj, storage_dict):
     """
     Parse a callable object to a convenient dictionary for CLI creation.
@@ -325,23 +366,25 @@ def create_CLI(cli_parser, interface_name, parameters):
     common_group.add_argument(
         "-b",
         dest="begin",
-        type=float,
-        default=0,
-        help="start time (ps) for evaluation. (default: %(default)s)"
+        type=str,
+        default="0",
+        help="frame or start time for evaluation. (default: %(default)s)"
     )
 
     common_group.add_argument(
-        "-e", dest="end", type=float, default=None,
-        help="end time (ps) for evaluation. (default: %(default)s)"
+        "-e",
+        dest="end",
+        type=str,
+        default="-1",
+        help="frame or end time for evaluation. (default: %(default)s)"
     )
 
     common_group.add_argument(
         "-dt",
         dest="dt",
-        type=float,
-        default=0,
-        help="time step (ps) to read analysis frame. "
-             "If `0` take all frames (default: %(default)s)"
+        type=str,
+        default="1",
+        help="step or time step for evaluation. (default: %(default)s)"
     )
 
     common_group.add_argument(
@@ -457,28 +500,14 @@ def main(
 
     with warnings.catch_warnings():
         warnings.simplefilter('always')
-        begin = analysis_kwargs.pop("begin")
-        if begin > u.trajectory.totaltime:
-            raise ValueError("Start ({:.2f} ps) is larer than total time "
-                             "({:.2f} ps).".format(analysis_kwargs["begin"],
-                                                   u.trajectory.totaltime))
-        elif begin > 0:
-            startframe = int(analysis_kwargs["begin"] // u.trajectory.dt)
-        else:
-            startframe = 0
+        startframe = convert_str_time(analysis_kwargs.pop("begin"), u.trajectory.dt)
+        if startframe > u.trajectory.n_frames:
+            raise ValueError("Start frame {} is larger than total number of frames "
+                             "{}.".format(startframe,
+                                          u.trajectory.n_frames))
 
-        end = analysis_kwargs.pop("end")
-        if end is not None:
-            stopframe = int(analysis_kwargs["end"] // u.trajectory.dt)
-            analysis_kwargs["end"] += 1  # catch also last frame in loops
-        else:
-            stopframe = None
-
-        dt = analysis_kwargs.pop("dt")
-        if dt > 0:
-            step = int(analysis_kwargs["dt"] // u.trajectory.dt)
-        else:
-            step = 1
+        stopframe = convert_str_time(analysis_kwargs.pop("end"), u.trajectory.dt)
+        step = convert_str_time(analysis_kwargs.pop("dt"), u.trajectory.dt)
 
     # Collect paramaters not necessary for initilizing ac object.
     verbose = analysis_kwargs.pop("verbose")

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+# -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding:utf-8 -*-
+#
+# Copyright (c) 2020 Authors and contributors
+#
+# Released under the GNU Public Licence, v2 or any higher version
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+import pytest
+import sys
+
+# Workaround since we have no real module
+sys.path.append("..")
+
+from cli_main import convert_str_time
+
+
+@pytest.mark.parametrize('x, frame',
+                         (('1', 1),
+                          ('-1', -1),
+                          ('1ns', 1000),
+                          ('12e3', 12e3),
+                          ('12e3ps', 12e3)))
+def test_convert_str_time(x, frame):
+    assert frame == convert_str_time(x, dt=1)
+
+
+def test_convert_str_time_dt():
+    assert 1 == convert_str_time("10ps", dt=10)
+
+
+def test_convert_str_time_raise():
+    with pytest.raises(ValueError):
+        convert_str_time('0.1', dt=1)


### PR DESCRIPTION
As discussed in #13 this PR allows input of `-b` `-e`, `-dt` either as time with SI prefixes or bare frame numbers.