### PR TITLE
Raise Error if `AtomGroup` from selection is empty

### DIFF
--- a/cli_main.py
+++ b/cli_main.py
@@ -447,7 +447,13 @@ def main(
     params = parse_docs(analysis_callable)[2]  # Index [2] for paramaters
     for param_name, dictionary in params.items():
         if "AtomGroup" in dictionary['type']:
-            analysis_kwargs[param_name] = u.select_atoms(analysis_kwargs[param_name])
+            sel = u.select_atoms(analysis_kwargs[param_name])
+            if len(sel) > 0:
+                analysis_kwargs[param_name] = sel
+            else:
+                raise ValueError("AtomGroup `-{}` with selection `{}` does not "
+                                 "contain any atoms".format(param_name,
+                                                            analysis_kwargs[param_name]))
 
     with warnings.catch_warnings():
         warnings.simplefilter('always')


### PR DESCRIPTION
More verbose feedback when input leads to empty AtomGroups. 

The current errror message is
```bash
./cli_main.py DensityAnalysis -f data/traj.trr -s data/topol.tpr  -atomgroup "name OWa"
Error: zero-size array to reduction operation minimum which has no identity
```

new one

```
./cli_main.py DensityAnalysis -f data/traj.trr -s data/topol.tpr  -atomgroup "name OWa"
Error: AtomGroup `-atomgroup` with selection `name OWa` does not contain any atoms
```

I'm no sure if a `ValueError` is actually the best choice...