### PR TITLE
Rename references from master to main branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,9 +2,9 @@ name: test_docs
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   build:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,11 +1,11 @@
 # Lint tests run on PR
-# but should not run after push to master because reporting
+# but should not run after push to main because reporting
 # these after push is meaningless to the building of the package
 name: lint
 
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   build:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,10 +1,10 @@
 # tests required for Pull Requests
-# but should not run after push to master
+# but should not run after push to main
 name: PR Requirements
 
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   build:

--- a/.github/workflows/py36.yml
+++ b/.github/workflows/py36.yml
@@ -2,9 +2,9 @@ name: test_py36
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   build:

--- a/.github/workflows/py37.yml
+++ b/.github/workflows/py37.yml
@@ -2,9 +2,9 @@ name: test_py37
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   build:

--- a/.github/workflows/py38.yml
+++ b/.github/workflows/py38.yml
@@ -2,9 +2,9 @@ name: test_py38
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   build:

--- a/.github/workflows/py39.yml
+++ b/.github/workflows/py39.yml
@@ -2,9 +2,9 @@ name: test_py39
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   build:

--- a/.github/workflows/version-bump-and-package.yml
+++ b/.github/workflows/version-bump-and-package.yml
@@ -3,7 +3,7 @@
 #on:
 #  push:
 #    branches:
-#      - master
+#      - main
 #
 #jobs:
 #  bump-version:
@@ -65,7 +65,7 @@
 #        bump2version patch
 #      if: env.SKIPBUMP == 'FALSE'
 #
-#    - name: Commit version change to master
+#    - name: Commit version change to main
 #      run: |
 #        git push --follow-tags
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -13,6 +13,7 @@ exclude tox.ini
 
 prune devtools
 prune tests
+prune data
 
 global-exclude *.py[cod] __pycache__/* *.so *.dylib 
 global-exclude tags

--- a/README.rst
+++ b/README.rst
@@ -16,3 +16,5 @@ and run ``mdacli``,
 ```bash
 mdacli -h
 ```
+
+version v0.0.0

--- a/docs/CONTRIBUTING.rst
+++ b/docs/CONTRIBUTING.rst
@@ -23,16 +23,16 @@ Keep your fork up to date
 
 It is important to keep your fork up-to-date with the main repository. Inside the forked project folder, every time you wish to update your fork with the main (upstream) repository do the following::
 
-    git checkout master
+    git checkout main
 
     # add the upstream only the very first time
     git remote add upstream git://github.com/PicoCentauri/mda_cli.git
 
     git fetch upstream
-    git merge upstream/master
-    git pull origin master
+    git merge upstream/main
+    git pull origin main
 
-While you are developing on a branch, you can keep it up to date with the upstream master by repeating the above commands and replacing ``master`` by the name of your development branch.
+While you are developing on a branch, you can keep it up to date with the upstream main by repeating the above commands and replacing ``main`` by the name of your development branch.
 
 Install for developers
 ----------------------
@@ -71,11 +71,11 @@ Thanks to the ``develop`` flag, any changes in the code will be automatically re
 Make a new branch
 -----------------
 
-From the ``master`` branch create a new branch where to develop the new code.
+From the ``main`` branch create a new branch where to develop the new code.
 
 ::
 
-    git checkout master
+    git checkout main
     git checkout -b new_branch
 
 
@@ -113,7 +113,7 @@ Once you are finished, you can Pull Request you additions to the main repository
 
 **Before submitting a Pull Request, verify your development branch passes all tests as** :ref:`described bellow<Uniformed Tests with tox>` **. If you are developing new code you should also implement new test cases.**
 
-Also, before PR, update your development branch to the upstream master branch.
+Also, before PR, update your development branch to the upstream main branch.
 
 Uniformed Tests with tox
 ------------------------
@@ -148,9 +148,9 @@ Also, you can run individual environments if you wish to test only specific func
 
 
 .. _Tox: https://tox.readthedocs.io/en/latest/
-.. _MANIFEST.in: https://github.com/PicoCentauri/mda_cli/blob/master/MANIFEST.in
+.. _MANIFEST.in: https://github.com/PicoCentauri/mda_cli/blob/main/MANIFEST.in
 .. _Fork this repository before contributing: https://github.com/PicoCentauri/mda_cli/network/members
 .. _Pull Request: https://github.com/PicoCentauri/mda_cli/pulls
-.. _PULLREQUEST.rst: https://github.com/PicoCentauri/mda_cli/blob/master/docs/PULLREQUEST.rst
+.. _PULLREQUEST.rst: https://github.com/PicoCentauri/mda_cli/blob/main/docs/PULLREQUEST.rst
 .. _Installing packages using pip and virtual environments: https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment
 .. _Anaconda: https://www.anaconda.com/

--- a/docs/PULLREQUEST.rst
+++ b/docs/PULLREQUEST.rst
@@ -6,5 +6,5 @@ Thank you for contributing to this project! Before you submit a Pull Request:
 * summarize the approach used to address the issue
 
 
-.. _contribution guidelines: https://github.com/PicoCentauri/mda_cli/blob/master/docs/CONTRIBUTING.rst
+.. _contribution guidelines: https://github.com/PicoCentauri/mda_cli/blob/main/docs/CONTRIBUTING.rst
 .. _issue: https://github.com/PicoCentauri/mda_cli/issues


### PR DESCRIPTION
* Rename references from master to main branch
* Prunes data folder in MANIFEST.in
* Adds version number to `README.rst` to maintain compatibility to `bumpversion`. Can be removed later if needed.