### PR TITLE
fix link in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ MDAnalysis command line interface
 ``mdacli`` is a simple command line interface (CLI) to the analysis classes of `MDAnalysis`_
 using argparse_. `Contributions are welcome <https://github.com/MDAnalysis/mdacli/blob/main/docs/CONTRIBUTING.rst>`_!
 
-To install ``mdacli`` refer to the `INSTALL file <https://github.com/MDAnalysis/mdacli/blob/main/docs/rst/installation.rst>`_.
+To install ``mdacli`` refer to the `INSTALL file <https://github.com/MDAnalysis/mdacli/blob/main/docs/src/installation.rst>`_.
 
 Run ``mdacli``::
 

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -5,6 +5,8 @@ Changelog
 Unreleased
 ----------
 
+* Fix installation link in README
+
 v0.1.34 (2025-12-02)
 ------------------------------------------
 


### PR DESCRIPTION


<!-- readthedocs-preview mdacli start -->
----
📚 Documentation preview 📚: https://mdacli--132.org.readthedocs.build/en/132/

<!-- readthedocs-preview mdacli end -->