### PR TITLE
Switch to root logger in setup_logging

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog
 Unreleased
 ----------
 
+* Change internal handling of loggers
 * Fix installation link in README
 
 v0.1.34 (2025-12-02)

--- a/src/mdacli/cli.py
+++ b/src/mdacli/cli.py
@@ -10,7 +10,6 @@
 import logging
 import sys
 import traceback
-import warnings
 
 import argcomplete
 from MDAnalysis.analysis.base import AnalysisBase

--- a/src/mdacli/cli.py
+++ b/src/mdacli/cli.py
@@ -111,9 +111,6 @@ def cli(
 
     if args.debug:
         level = logging.DEBUG
-    else:
-        # Ignore all warnings if not in debug mode, because MDA is noisy
-        warnings.filterwarnings("ignore")
 
     with setup_logging(logfile=args.logfile, level=level):
         # Execute the main client interface.

--- a/src/mdacli/cli.py
+++ b/src/mdacli/cli.py
@@ -27,8 +27,6 @@ from .libcli import (
 from .logger import setup_logging
 from .utils import _exit_if_a_is_b
 
-logger = logging.getLogger(__name__)
-
 
 def cli(
     name,
@@ -117,7 +115,7 @@ def cli(
         # Ignore all warnings if not in debug mode, because MDA is noisy
         warnings.filterwarnings("ignore")
 
-    with setup_logging(logger, logfile=args.logfile, level=level):
+    with setup_logging(logfile=args.logfile, level=level):
         # Execute the main client interface.
         try:
             analysis_callable = args.analysis_callable

--- a/src/mdacli/libcli.py
+++ b/src/mdacli/libcli.py
@@ -20,7 +20,6 @@ from pathlib import Path
 import MDAnalysis as mda
 from MDAnalysis.transformations.boxdimensions import set_dimensions
 
-from .colors import Emphasise
 from .save import save
 from .utils import convert_str_time, parse_callable_signature, parse_docs
 
@@ -43,13 +42,6 @@ STR_TYPE_DICT = {
     "MDAnalysis.core.universe.Universe": mda.Universe,
     "Universe": mda.Universe,
 }
-
-
-def _warning(message, *args, **kwargs):  # NOQA: ARG001
-    logger.warning(Emphasise.warning(message))
-
-
-warnings.showwarning = _warning
 
 
 class KwargsDict(argparse.Action):

--- a/src/mdacli/logger.py
+++ b/src/mdacli/logger.py
@@ -66,11 +66,13 @@ def setup_logging(
         message logged from errors, warnings and infos will be displayed.
     """
     try:
+        # Get the root logger
         logobj = logging.getLogger()
 
-        format = ""
         if level == logging.DEBUG:
-            format += "[{levelname}]:{filename}:{funcName}:{lineno} - "
+            format = "[{levelname}]:{filename}:{funcName}:{lineno} - "
+        else:
+            format = ""
         format += "{message}"
 
         formatter = logging.Formatter(format, style="{")
@@ -91,8 +93,6 @@ def setup_logging(
             logging.addLevelName(logging.WARNING, Emphasise.warning("WARNING"))
             logging.addLevelName(logging.ERROR, Emphasise.error("ERROR"))
 
-        logging.captureWarnings(True)
-
         logobj.setLevel(level)
         for handler in handlers:
             handler.setLevel(level)
@@ -104,6 +104,9 @@ def setup_logging(
             logobj.info(f"This log is also available at '{abs_path}'.")
         else:
             logobj.debug("Logging to file is disabled.")
+
+        # Redirect warnings (from the warnings library) to the logging system
+        logging.captureWarnings(True)
 
         yield
 

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -41,9 +41,7 @@ def test_warnings_in_log(caplog):
     Keep this test at the top since it seems otherwise there are some pytest
     issues...
     """
-    logger = logging.getLogger()
-
-    with setup_logging(logger):
+    with setup_logging():
         warnings.warn("A warning", stacklevel=1)
 
     assert "A warning" in caplog.text
@@ -54,7 +52,7 @@ def test_default_log(caplog, capsys):
     caplog.set_level(logging.INFO)
     logger = logging.getLogger()
 
-    with setup_logging(logger, level=logging.INFO):
+    with setup_logging(level=logging.INFO):
         logger.info("foo")
         logger.debug("A debug message")
 
@@ -72,7 +70,7 @@ def test_info_log(caplog, monkeypatch, tmp_path, capsys):
     caplog.set_level(logging.INFO)
     logger = logging.getLogger()
 
-    with setup_logging(logger, logfile="logfile.log", level=logging.INFO):
+    with setup_logging(logfile="logfile.log", level=logging.INFO):
         logger.info("foo")
         logger.debug("A debug message")
 
@@ -97,7 +95,7 @@ def test_debug_log(caplog, monkeypatch, tmp_path, capsys):
     caplog.set_level(logging.DEBUG)
     logger = logging.getLogger()
 
-    with setup_logging(logger, logfile="logfile.log", level=logging.DEBUG):
+    with setup_logging(logfile="logfile.log", level=logging.DEBUG):
         logger.info("foo")
         logger.debug("A debug message")
 


### PR DESCRIPTION
This PR changes the way `mdacli.logger.setup_logging` works.

Since mdacli is invoked from the command line, we do not need to worry about handling different loggers. To make things simpler and less error-prone, the method was changed to only work on the root logger. 

Software that uses mdacli just configures its loggers (see https://docs.python.org/3/library/logging.html#logger-objects for details on how this should be done) and the logs propagate to the root logger and get handled by mdacli.

<!-- readthedocs-preview mdacli start -->
----
📚 Documentation preview 📚: https://mdacli--133.org.readthedocs.build/en/133/

<!-- readthedocs-preview mdacli end -->