### PR TITLE
Use rounding instead of // in convert_str_time

### DIFF
--- a/docs/AUTHORS.rst
+++ b/docs/AUTHORS.rst
@@ -7,3 +7,4 @@ Authors
 * Lily Wang (`github-lw <https://github.com/lilyminium>`_)
 * Henrik Jäger (`github-hj <https://github.com/hejamu>`_)
 * Shreejan Dolai (`github-sd <https://github.com/spyke7>`_)
+* Damien Toquer (`github-sd <https://github.com/DamienTOQUER>`_)

--- a/docs/AUTHORS.rst
+++ b/docs/AUTHORS.rst
@@ -7,4 +7,4 @@ Authors
 * Lily Wang (`github-lw <https://github.com/lilyminium>`_)
 * Henrik Jäger (`github-hj <https://github.com/hejamu>`_)
 * Shreejan Dolai (`github-sd <https://github.com/spyke7>`_)
-* Damien Toquer (`github-sd <https://github.com/DamienTOQUER>`_)
+* Damien Toquer (`github-dt <https://github.com/DamienTOQUER>`_)

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -5,6 +5,8 @@ Changelog
 Unreleased
 ----------
 
+* Fix convert_str_time in util
+
 v0.2.0 (2026-01-23)
 ------------------------------------------
 

--- a/src/mdacli/utils.py
+++ b/src/mdacli/utils.py
@@ -72,14 +72,14 @@ def convert_str_time(x, dt):
 
     Notes
     -----
-    The end value is rounded to the 9th number to avoid floating point errors. If we
-    don't use the 9 digits then the floating point behaviour of np.floor would be
-    unstable, i.e.:
+    The quotient ``val / dt`` is rounded to 9 decimal places before flooring
+    so that values that should land exactly on a frame boundary are not
+    pushed down by floating-point error. For example:
 
-        >>> np.floor(0.999999999999999999)
-        np.float64(1.0)
-        >>> np.floor(0.9999999999999999)
-        np.float64(0.0)
+        >>> np.floor(0.3 / 0.1)
+        np.float64(2.0)
+        >>> np.floor(np.round(0.3 / 0.1, 9))
+        np.float64(3.0)
     """
     val, unit = split_time_unit(x)
     if unit != "":

--- a/src/mdacli/utils.py
+++ b/src/mdacli/utils.py
@@ -53,6 +53,13 @@ def convert_str_time(x, dt):
 
     See :func:`split_time_unit`.
 
+    If we don't use the 9 digits then the floating point behaviour of np.floor would be
+    unstable, i.e.:
+        np.floor(0.999999999999999999)
+            -> np.float64(1.0)
+        np.floor(0.9999999999999999)
+            -> np.float64(0.0)
+
     Parameters
     ----------
     x : str

--- a/src/mdacli/utils.py
+++ b/src/mdacli/utils.py
@@ -13,6 +13,7 @@ import sys
 from collections import defaultdict
 
 import MDAnalysis as mda
+import numpy as np
 
 
 def _exit_if_a_is_b(obj1, obj2, msg):

--- a/src/mdacli/utils.py
+++ b/src/mdacli/utils.py
@@ -72,7 +72,7 @@ def convert_str_time(x, dt):
     val, unit = split_time_unit(x)
     if unit != "":
         val = mda.units.convert(val, unit, "ps")
-        return round(val / dt)
+        return int(np.floor(np.round(val / dt, 9)))
     if val % 1 != 0:  # the number is not int'able
         raise ValueError(
             "Only integers or time step combinations (´12ps´) "

--- a/src/mdacli/utils.py
+++ b/src/mdacli/utils.py
@@ -53,19 +53,21 @@ def convert_str_time(x, dt):
 
     See :func:`split_time_unit`.
 
-    If we don't use the 9 digits then the floating point behaviour of np.floor would be
-    unstable, i.e.:
-        np.floor(0.999999999999999999)
-            -> np.float64(1.0)
-        np.floor(0.9999999999999999)
-            -> np.float64(0.0)
-
     Parameters
     ----------
     x : str
         the input string
     dt : float
         the time step in ps
+
+    Notes
+    -----
+    If we don't use the 9 digits then the floating point behaviour of np.floor would be
+    unstable, i.e.:
+        >>> np.floor(0.999999999999999999)
+        np.float64(1.0)
+        >>> np.floor(0.9999999999999999)
+        np.float64(0.0)
 
     Returns
     -------

--- a/src/mdacli/utils.py
+++ b/src/mdacli/utils.py
@@ -72,7 +72,7 @@ def convert_str_time(x, dt):
     val, unit = split_time_unit(x)
     if unit != "":
         val = mda.units.convert(val, unit, "ps")
-        return int(val // dt)
+        return round(val / dt)
     if val % 1 != 0:  # the number is not int'able
         raise ValueError(
             "Only integers or time step combinations (´12ps´) "

--- a/src/mdacli/utils.py
+++ b/src/mdacli/utils.py
@@ -60,15 +60,6 @@ def convert_str_time(x, dt):
     dt : float
         the time step in ps
 
-    Notes
-    -----
-    If we don't use the 9 digits then the floating point behaviour of np.floor would be
-    unstable, i.e.:
-        >>> np.floor(0.999999999999999999)
-        np.float64(1.0)
-        >>> np.floor(0.9999999999999999)
-        np.float64(0.0)
-
     Returns
     -------
     int
@@ -78,6 +69,17 @@ def convert_str_time(x, dt):
     ------
     ValueError
         The input does not contain any units but is not an integer.
+
+    Notes
+    -----
+    The end value is rounded to the 9th number to avoid floating point errors. If we
+    don't use the 9 digits then the floating point behaviour of np.floor would be
+    unstable, i.e.:
+    
+        >>> np.floor(0.999999999999999999)
+        np.float64(1.0)
+        >>> np.floor(0.9999999999999999)
+        np.float64(0.0)
     """
     val, unit = split_time_unit(x)
     if unit != "":

--- a/src/mdacli/utils.py
+++ b/src/mdacli/utils.py
@@ -75,7 +75,7 @@ def convert_str_time(x, dt):
     The end value is rounded to the 9th number to avoid floating point errors. If we
     don't use the 9 digits then the floating point behaviour of np.floor would be
     unstable, i.e.:
-    
+
         >>> np.floor(0.999999999999999999)
         np.float64(1.0)
         >>> np.floor(0.9999999999999999)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -44,6 +44,18 @@ def test_convert_str_time(x, frame):
     assert frame == convert_str_time(x, dt=1)
 
 
+@pytest.mark.parametrize(
+    ("x", "frame"),
+    [
+        ("1ps", 10),
+        ("0.1ps", 1),
+    ],
+)
+def test_convert_str_time_decimaldt(x, frame):
+    """Test convert string to time with decimal dt."""
+    assert frame == convert_str_time(x, dt=0.1)
+
+
 def test_convert_str_time_dt():
     """Test convert string to time in ps."""
     assert convert_str_time("10ps", dt=10) == 1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -49,6 +49,7 @@ def test_convert_str_time(x, frame):
     [
         ("1ps", 10),
         ("0.1ps", 1),
+        ("0.3ps", 3),
     ],
 )
 def test_convert_str_time_decimaldt(x, frame):


### PR DESCRIPTION
Change integer division to rounding for str to frame conversion. Solve #137 

<!-- readthedocs-preview mdacli start -->
----
📚 Documentation preview 📚: https://mdacli--138.org.readthedocs.build/en/138/

<!-- readthedocs-preview mdacli end -->