### PR TITLE
restrict RTD to epub as extra format

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,7 +16,9 @@ sphinx:
   configuration: docs/src/conf.py
 
 # Optionally build your docs in additional formats such as PDF and ePub
-formats: all
+# (LaTeX/PDF is currently broken, see gh-140)
+formats:
+  - epub
 
 # Optionally set the version of Python and requirements required to build your docs
 python:

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -6,6 +6,7 @@ Unreleased
 ----------
 
 * Fix convert_str_time in util
+* Have ReadTheDocs only produce Epub as extra format (#140)
 
 v0.2.0 (2026-01-23)
 ------------------------------------------


### PR DESCRIPTION
- fix #140
- remove PDF from extra formats (as it is currently broken)

<!-- readthedocs-preview mdacli start -->
----
📚 Documentation preview 📚: https://mdacli--141.org.readthedocs.build/en/141/

<!-- readthedocs-preview mdacli end -->